### PR TITLE
Install ice

### DIFF
--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -39,11 +39,9 @@ jobs:
           gradle-version: ${{ inputs.gradle-version }}
         if: |
           (startsWith(matrix.os, 'ubuntu-latest')) ||
-          (inputs.install-ice == 'false' && startsWith(matrix.os, 'windows-latest')) ||
-          (inputs.install-ice == 'false' && startsWith(matrix.os, 'macos-latest'))
+          (inputs.install-ice == 'false')
       - name: Run commands
         run: ./gradlew ${{ inputs.gradle-commands }}
         if: |
           (startsWith(matrix.os, 'ubuntu-latest')) ||
-          (inputs.install-ice == 'false' && startsWith(matrix.os, 'windows-latest')) ||
-          (inputs.install-ice == 'false' && startsWith(matrix.os, 'macos-latest'))
+          (inputs.install-ice == 'false')

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -37,7 +37,13 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           gradle-version: ${{ inputs.gradle-version }}
-        if: ${{ inputs.install-ice == 'true' && startsWith(matrix.os, 'ubuntu-latest') }}
+        if: |
+          (startsWith(matrix.os, 'ubuntu-latest')) ||
+          (inputs.install-ice == 'false' && startsWith(matrix.os, 'windows-latest')) ||
+          (inputs.install-ice == 'false' && startsWith(matrix.os, 'macos-latest'))
       - name: Run commands
         run: ./gradlew ${{ inputs.gradle-commands }}
-        if: ${{ inputs.install-ice == 'true' && startsWith(matrix.os, 'ubuntu-latest') }}
+        if: |
+          (startsWith(matrix.os, 'ubuntu-latest')) ||
+          (inputs.install-ice == 'false' && startsWith(matrix.os, 'windows-latest')) ||
+          (inputs.install-ice == 'false' && startsWith(matrix.os, 'macos-latest'))

--- a/.github/workflows/gradle_build.yml
+++ b/.github/workflows/gradle_build.yml
@@ -12,6 +12,10 @@ on:
         required: false
         default: build
         type: string
+      install-ice:
+        required: false
+        default: false
+        type: string
 
 
 jobs:
@@ -21,12 +25,19 @@ jobs:
         java: [1.8, 11]
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      ICE_HOME: /opt/ice-3.6.5
     steps:
       - uses: actions/checkout@v2
+      - name: Install Ice and Ice python binding
+        uses: ome/action-ice@v1
+        if: ${{ inputs.install-ice == 'true' && startsWith(matrix.os, 'ubuntu-latest') }}
       - name: Set up environment
         uses: ome/action-gradle@v1
         with:
           java-version: ${{ matrix.java }}
           gradle-version: ${{ inputs.gradle-version }}
+        if: ${{ inputs.install-ice == 'true' && startsWith(matrix.os, 'ubuntu-latest') }}
       - name: Run commands
         run: ./gradlew ${{ inputs.gradle-commands }}
+        if: ${{ inputs.install-ice == 'true' && startsWith(matrix.os, 'ubuntu-latest') }}

--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -19,10 +19,6 @@ on:
         type: string
         required: false
         default: 1.8
-      install-ice:
-        required: false
-        default: false
-        type: string
     secrets:
       ARTIFACTORY_USER:
         required: true
@@ -42,7 +38,6 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Ice and Ice python binding
         uses: ome/action-ice@v1
-        if: ${{ inputs.install-ice == 'true' }}
       - name: Set up environment
         uses: ome/action-gradle@v1
         with:

--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -19,6 +19,10 @@ on:
         type: string
         required: false
         default: 1.8
+      install-ice:
+        required: false
+        default: false
+        type: string
     secrets:
       ARTIFACTORY_USER:
         required: true
@@ -32,8 +36,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      ICE_HOME: /opt/ice-3.6.5
     steps:
       - uses: actions/checkout@v2
+      - name: Install Ice and Ice python binding
+        uses: ome/action-ice@v1
+        if: ${{ inputs.install-ice == 'true' }}
       - name: Set up environment
         uses: ome/action-gradle@v1
         with:

--- a/.github/workflows/gradle_publish.yml
+++ b/.github/workflows/gradle_publish.yml
@@ -19,6 +19,10 @@ on:
         type: string
         required: false
         default: 1.8
+      install-ice:
+        required: false
+        default: false
+        type: string
     secrets:
       ARTIFACTORY_USER:
         required: true
@@ -38,6 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Ice and Ice python binding
         uses: ome/action-ice@v1
+        if: ${{ inputs.install-ice == 'true' }}
       - name: Set up environment
         uses: ome/action-gradle@v1
         with:


### PR DESCRIPTION
* Change required to install Ice. ``slice2java`` is required to build ``omero-server``
* Setting ``ICE_HOME`` does not work if set ``action-ice``.
* Ideally the ``matrix.os`` should be set to ``ubuntu-latest`` when the new ``install-ice`` parameter is ``true`` but I have not found a way to sort that out yet. So for now we use ``if`` and multiple conditions.

Since ``gradle_publish`` is run on ``ubuntu-latest``, I have opted to install ice by default to simplify the workflow i.e. no parameter

Tested with passing 
* ``install-ice: false``: Error expected See https://github.com/jburel/omero-server/actions/runs/2453934204
* ``install-ice: true``: https://github.com/jburel/omero-server/actions/runs/2453941406

If we are happy with the change, we bump the version to 1.2 and adjust https://github.com/ome/omero-server/pull/143 accordingly
